### PR TITLE
fix segfault(file->log is NULL), logger fault

### DIFF
--- a/ngx_markdown_filter_module.c
+++ b/ngx_markdown_filter_module.c
@@ -139,6 +139,7 @@ static char *ngx_conf_set_template(ngx_conf_t *cf, ngx_command_t *cmd, void *con
     ngx_file_t file;
     file.fd = fd;
     file.info = fi;
+    file.log = cf->log;
 
     ngx_int_t n = ngx_read_file(&file, template, fi.st_size, 0);
     template[fi.st_size] = '\0';


### PR DESCRIPTION
![изображение](https://github.com/ukarim/ngx_markdown_filter_module/assets/28489754/803907a4-614c-4711-8c35-dea5683cbb65)
 without this line, it crashes with a segfault, because it tries to log, but file->log NULL