### PR TITLE
Find lib by name rather than file

### DIFF
--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 ngx_module_type=HTTP_FILTER
 ngx_module_name=ngx_markdown_filter_module
 ngx_module_srcs="$ngx_addon_dir/ngx_markdown_filter_module.c"
-ngx_module_libs=-l:libcmark.so
+ngx_module_libs=-lcmark
 
 . auto/module
 

--- a/config_gfm
+++ b/config_gfm
@@ -1,7 +1,7 @@
 ngx_module_type=HTTP_FILTER
 ngx_module_name=ngx_markdown_filter_module
 ngx_module_srcs="$ngx_addon_dir/ngx_markdown_filter_module.c"
-ngx_module_libs="-l:libcmark-gfm.so -l:libcmark-gfm-extensions.so"
+ngx_module_libs="-lcmark-gfm -lcmark-gfm-extensions"
 
 . auto/module
 


### PR DESCRIPTION
This fixes problems I was having with nixos when the library isn't placed in a searched path by default.